### PR TITLE
Fix ternary macro

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1361,10 +1361,10 @@ this.sibilant = (function() {
   sibilant.macros.namespaces.core.ternary = (function ternary$(cond, ifTrue, ifFalse) {
     /* ternary src/macros/flow-control.sibilant:9:0 */
   
-    return [ "(", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse) ];
+    return [ "(function() {", indent([ "return (", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse), ";" ]), "}).call(this)" ];
   });
   sibilant.macros.namespaces.core.when = (function when$(condition, body) {
-    /* when src/macros/flow-control.sibilant:21:0 */
+    /* when src/macros/flow-control.sibilant:26:0 */
   
     var body = Array.prototype.slice.call(arguments, 1);
   
@@ -1372,13 +1372,13 @@ this.sibilant = (function() {
       file: "src/macros/flow-control.sibilant",
       token: "(",
       type: "expression",
-      line: 24,
+      line: 29,
       col: 18,
       contents: [ {
         file: "src/macros/flow-control.sibilant",
         token: "do",
         type: "literal",
-        line: 24,
+        line: 29,
         col: 19,
         contents: [],
         specials: 0,
@@ -1392,7 +1392,7 @@ this.sibilant = (function() {
     }), "}");
   });
   sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
-    /* unless src/macros/flow-control.sibilant:33:0 */
+    /* unless src/macros/flow-control.sibilant:38:0 */
   
     var body = Array.prototype.slice.call(arguments, 1);
   
@@ -1400,13 +1400,13 @@ this.sibilant = (function() {
       file: "src/macros/flow-control.sibilant",
       token: "(",
       type: "expression",
-      line: 35,
+      line: 40,
       col: 25,
       contents: [ {
         file: "src/macros/flow-control.sibilant",
         token: "not",
         type: "literal",
-        line: 35,
+        line: 40,
         col: 26,
         contents: [],
         specials: 0,
@@ -1421,13 +1421,13 @@ this.sibilant = (function() {
       file: "src/macros/flow-control.sibilant",
       token: "(",
       type: "expression",
-      line: 36,
+      line: 41,
       col: 33,
       contents: [ {
         file: "src/macros/flow-control.sibilant",
         token: "do",
         type: "literal",
-        line: 36,
+        line: 41,
         col: 34,
         contents: [],
         specials: 0,
@@ -1441,12 +1441,12 @@ this.sibilant = (function() {
     }), "}" ]), "}).call(this)" ];
   });
   sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranches) {
-    /* if src/macros/flow-control.sibilant:58:0 */
+    /* if src/macros/flow-control.sibilant:63:0 */
   
     var alternatingConditionsAndBranches = Array.prototype.slice.call(arguments, 0);
   
     return [ "(function() {", indent(interleave(" else ", bulkMap(alternatingConditionsAndBranches, (function(cond, val) {
-      /* src/macros/flow-control.sibilant:63:25 */
+      /* src/macros/flow-control.sibilant:68:25 */
     
       return (function() {
         if (typeof val !== "undefined") {
@@ -1454,13 +1454,13 @@ this.sibilant = (function() {
             file: "src/macros/flow-control.sibilant",
             token: "(",
             type: "expression",
-            line: 66,
+            line: 71,
             col: 44,
             contents: [ {
               file: "src/macros/flow-control.sibilant",
               token: "do",
               type: "literal",
-              line: 66,
+              line: 71,
               col: 45,
               contents: [],
               specials: 0,
@@ -1477,13 +1477,13 @@ this.sibilant = (function() {
             file: "src/macros/flow-control.sibilant",
             token: "(",
             type: "expression",
-            line: 68,
+            line: 73,
             col: 47,
             contents: [ {
               file: "src/macros/flow-control.sibilant",
               token: "do",
               type: "literal",
-              line: 68,
+              line: 73,
               col: 48,
               contents: [],
               specials: 0,

--- a/lib/options.js
+++ b/lib/options.js
@@ -243,7 +243,9 @@ var mergeWith = (function mergeWith$(into, from) {
 var extractOptions = (function extractOptions$(config, args) {
   /* extract-options src/options.sibilant:3:0 */
 
-  args = (typeof args !== "undefined") ? args : process.argv.slice(2);
+  args = (function() {
+    return (typeof args !== "undefined") ? args : process.argv.slice(2);
+  }).call(this);
   var defaultLabel = "unlabeled",
       currentLabel = defaultLabel,
       afterBreak = false,

--- a/lib/sibilant.js
+++ b/lib/sibilant.js
@@ -37,7 +37,9 @@ var relativeDirAndFile = sibilant.relativeDirAndFile;
 sibilant.recordDependency = (function sibilant$recordDependency$(from, to) {
   /* sibilant.record-dependency src/node.sibilant:17:0 */
 
-  sibilant.dependencies[from] = (typeof sibilant.dependencies[from] !== "undefined") ? sibilant.dependencies[from] : [];
+  sibilant.dependencies[from] = (function() {
+    return (typeof sibilant.dependencies[from] !== "undefined") ? sibilant.dependencies[from] : [];
+  }).call(this);
   return sibilant.dependencies[from].push(to);
 });
 sibilant.flatDependencies = (function sibilant$flatDependencies$() {
@@ -54,7 +56,9 @@ sibilant.entry = (function sibilant$entry$(source, options) {
       return source = undefined;
     }
   }).call(this);
-  options = (typeof options !== "undefined") ? options : {  };
+  options = (function() {
+    return (typeof options !== "undefined") ? options : {  };
+  }).call(this);
   (function() {
     if (typeof source === "string") {
       return options.source = source;
@@ -65,8 +69,12 @@ sibilant.entry = (function sibilant$entry$(source, options) {
       file = options.file,
       quoteKeys = options.quoteKeys,
       json = options.json;
-  map = (typeof map !== "undefined") ? map : false;
-  quoteKeys = (typeof quoteKeys !== "undefined") ? quoteKeys : json;
+  map = (function() {
+    return (typeof map !== "undefined") ? map : false;
+  }).call(this);
+  quoteKeys = (function() {
+    return (typeof quoteKeys !== "undefined") ? quoteKeys : json;
+  }).call(this);
   (function() {
     if (((typeof file !== "undefined" && file !== null) && !((typeof source !== "undefined" && source !== null)))) {
       var relativeDirAndF$4 = relativeDirAndFile(file),
@@ -357,8 +365,12 @@ var white = (function white$(args) {
 sibilant.prettyPrint = (function sibilant$prettyPrint$(node, color, entry) {
   /* sibilant.pretty-print src/pretty-printer.sibilant:3:0 */
 
-  entry = (typeof entry !== "undefined") ? entry : true;
-  color = (typeof color !== "undefined") ? color : true;
+  entry = (function() {
+    return (typeof entry !== "undefined") ? entry : true;
+  }).call(this);
+  color = (function() {
+    return (typeof color !== "undefined") ? color : true;
+  }).call(this);
   return realNewlines((function() {
     if (node__QUERY(node)) {
       var prettyPrinter = (sibilant.prettyPrint[node.type] || sibilant.prettyPrint.default);
@@ -811,13 +823,15 @@ var orderedRegexes = parser.orderedRegexes;
 parser.parse = (function parser$parse$(string, context) {
   /* parser.parse src/parser.sibilant:48:0 */
 
-  context = (typeof context !== "undefined") ? context : {
-    position: 0,
-    stack: [],
-    line: 1,
-    lastNewline: 0,
-    col: 0
-  };
+  context = (function() {
+    return (typeof context !== "undefined") ? context : {
+      position: 0,
+      stack: [],
+      line: 1,
+      lastNewline: 0,
+      col: 0
+    };
+  }).call(this);
   var match = true,
       regexName = null,
       remainingInput = string;
@@ -1345,10 +1359,10 @@ sibilant.macros.namespaces.core["="] = (function $$(args) {
 sibilant.macros.namespaces.core.ternary = (function ternary$(cond, ifTrue, ifFalse) {
   /* ternary src/macros/flow-control.sibilant:9:0 */
 
-  return [ "(", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse) ];
+  return [ "(function() {", indent([ "return (", transpile(cond), ") ? ", transpile(ifTrue), " : ", transpile(ifFalse), ";" ]), "}).call(this)" ];
 });
 sibilant.macros.namespaces.core.when = (function when$(condition, body) {
-  /* when src/macros/flow-control.sibilant:21:0 */
+  /* when src/macros/flow-control.sibilant:26:0 */
 
   var body = Array.prototype.slice.call(arguments, 1);
 
@@ -1356,13 +1370,13 @@ sibilant.macros.namespaces.core.when = (function when$(condition, body) {
     file: "src/macros/flow-control.sibilant",
     token: "(",
     type: "expression",
-    line: 24,
+    line: 29,
     col: 18,
     contents: [ {
       file: "src/macros/flow-control.sibilant",
       token: "do",
       type: "literal",
-      line: 24,
+      line: 29,
       col: 19,
       contents: [],
       specials: 0,
@@ -1376,7 +1390,7 @@ sibilant.macros.namespaces.core.when = (function when$(condition, body) {
   }), "}");
 });
 sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
-  /* unless src/macros/flow-control.sibilant:33:0 */
+  /* unless src/macros/flow-control.sibilant:38:0 */
 
   var body = Array.prototype.slice.call(arguments, 1);
 
@@ -1384,13 +1398,13 @@ sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
     file: "src/macros/flow-control.sibilant",
     token: "(",
     type: "expression",
-    line: 35,
+    line: 40,
     col: 25,
     contents: [ {
       file: "src/macros/flow-control.sibilant",
       token: "not",
       type: "literal",
-      line: 35,
+      line: 40,
       col: 26,
       contents: [],
       specials: 0,
@@ -1405,13 +1419,13 @@ sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
     file: "src/macros/flow-control.sibilant",
     token: "(",
     type: "expression",
-    line: 36,
+    line: 41,
     col: 33,
     contents: [ {
       file: "src/macros/flow-control.sibilant",
       token: "do",
       type: "literal",
-      line: 36,
+      line: 41,
       col: 34,
       contents: [],
       specials: 0,
@@ -1425,12 +1439,12 @@ sibilant.macros.namespaces.core.unless = (function unless$(condition, body) {
   }), "}" ]), "}).call(this)" ];
 });
 sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranches) {
-  /* if src/macros/flow-control.sibilant:58:0 */
+  /* if src/macros/flow-control.sibilant:63:0 */
 
   var alternatingConditionsAndBranches = Array.prototype.slice.call(arguments, 0);
 
   return [ "(function() {", indent(interleave(" else ", bulkMap(alternatingConditionsAndBranches, (function(cond, val) {
-    /* src/macros/flow-control.sibilant:63:25 */
+    /* src/macros/flow-control.sibilant:68:25 */
   
     return (function() {
       if (typeof val !== "undefined") {
@@ -1438,13 +1452,13 @@ sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranc
           file: "src/macros/flow-control.sibilant",
           token: "(",
           type: "expression",
-          line: 66,
+          line: 71,
           col: 44,
           contents: [ {
             file: "src/macros/flow-control.sibilant",
             token: "do",
             type: "literal",
-            line: 66,
+            line: 71,
             col: 45,
             contents: [],
             specials: 0,
@@ -1461,13 +1475,13 @@ sibilant.macros.namespaces.core.if = (function if$(alternatingConditionsAndBranc
           file: "src/macros/flow-control.sibilant",
           token: "(",
           type: "expression",
-          line: 68,
+          line: 73,
           col: 47,
           contents: [ {
             file: "src/macros/flow-control.sibilant",
             token: "do",
             type: "literal",
-            line: 68,
+            line: 73,
             col: 48,
             contents: [],
             specials: 0,
@@ -4134,7 +4148,9 @@ sibilant.macros.namespaces.core.comment = (function comment$(contents) {
     return [ "// ", recurseMap(transpile(content), (function(item) {
       /* src/macros/misc.sibilant:29:36 */
     
-      return (item) ? outputFormatter(transpile(item)).replace((new RegExp("\n", "g")), "\n// ") : null;
+      return (function() {
+        return (item) ? outputFormatter(transpile(item)).replace((new RegExp("\n", "g")), "\n// ") : null;
+      }).call(this);
     })) ];
   }));
 });
@@ -7108,8 +7124,12 @@ var generateSymbol = (function generateSymbol$(clue) {
   /* generate-symbol src/helpers.sibilant:171:0 */
 
   var state = sibilant.state;
-  clue = (typeof clue !== "undefined") ? clue : "temp";
-  state.symbolCounts = (typeof state.symbolCounts !== "undefined") ? state.symbolCounts : {  };
+  clue = (function() {
+    return (typeof clue !== "undefined") ? clue : "temp";
+  }).call(this);
+  state.symbolCounts = (function() {
+    return (typeof state.symbolCounts !== "undefined") ? state.symbolCounts : {  };
+  }).call(this);
   var count = ((state.symbolCounts[clue] || 0) + 1);
   state.symbolCounts[clue] = count;
   return [ ("" + clue + "$" + count) ];

--- a/src/macros/flow-control.sibilant
+++ b/src/macros/flow-control.sibilant
@@ -7,10 +7,15 @@
          "fifty is more than 100"))
 
 (macro ternary (cond if-true if-false)
-       ["(" (transpile cond) ") ? "
-            (transpile if-true) " : "
-            (transpile if-false)])
-
+       ["(function() {"
+        (indent ["return ("
+                 (transpile cond)
+                 ") ? "
+                 (transpile if-true)
+                 " : "
+                 (transpile if-false)
+                 ";"])
+        "}).call(this)"])
 
 (docs "evaluates statements in `body` if `condition` is true. `body`
       is `scoped` in a self-evaluating function to support having a

--- a/test/test.sibilant
+++ b/test/test.sibilant
@@ -144,6 +144,18 @@
   }
 }).call(this)")
 
+; ternary
+
+(assert-translation "(ternary a b c)"
+"(function() {
+  return (a) ? b : c;
+}).call(this)")
+
+(assert-translation "(\"prefix-\" (ternary true \"b\" \"c\") \"-suffix\")"
+"(\"prefix-\" + (function() {
+  return (true) ? \"b\" : \"c\";
+}).call(this) + \"-suffix\")")
+
 ; do
 
 (assert-translation "(do a b c d e)"
@@ -710,8 +722,12 @@ b();"))
 })"))
 
 (assert-translation "(default foo 1 bar 2)"
-                    "foo = (typeof foo !== \"undefined\") ? foo : 1;
-bar = (typeof bar !== \"undefined\") ? bar : 2;")
+                    "foo = (function() {
+  return (typeof foo !== \"undefined\") ? foo : 1;
+}).call(this);
+bar = (function() {
+  return (typeof bar !== \"undefined\") ? bar : 2;
+}).call(this);")
 
 
 (assert-translation "(pipe a (b c) (d e) (+ 1) (.to-string) (.to-upper-case))"


### PR DESCRIPTION
The transpiled output of the ternary macro previously lead to unexpected
behaviour when used within another expression such as string
concatenation. For example, when the following was transpiled and
evaluated as JavaScript, this previously produced an unexpected output
of "a" rather than the intended "prefix-a-suffix":

`(+ "prefix- " (ternary true "a" "b") "-suffix")`